### PR TITLE
fix: typo on description

### DIFF
--- a/content/posts/psql-rls-ts.md
+++ b/content/posts/psql-rls-ts.md
@@ -1,6 +1,6 @@
 ---
 title: "RLS and Full-Text Search - LEAKPROOF matters"
-description: "Postgre planner skips index use under RLS if operators aren't leakproof."
+description: "Postgres planner skips index use under RLS if operators aren't leakproof."
 date: 2024-12-01T10:00:00+02:00
 draft: false
 showToc: true


### PR DESCRIPTION
### Description

Fix typo